### PR TITLE
[PointNet] Add the missing input argument to fix the serial runner

### DIFF
--- a/benchmarks/pointnet.py
+++ b/benchmarks/pointnet.py
@@ -91,6 +91,7 @@ def main(args):
       enable_dcgm=args.enable_dcgm,
       epochs=args.epochs,
       iters_per_epoch=args.iters_per_epoch,
+      serial_runner_kwargs=args.serial_runner_kwargs,
       concurrent_runner_kwargs=args.concurrent_runner_kwargs,
       mps_runner_kwargs=args.mps_runner_kwargs,
       hfta_runner_kwargs=args.hfta_runner_kwargs,


### PR DESCRIPTION
* [x] Tested (on TPU with PointNet)
* [x] Formatted with YAPF

This missed argument caused failure to run SerialRunner. I would guess this will also happen on GPU.

Note that Peiming also modified this line in his pull request but with a different approach. I would prefer this approach because it has minimal modification.

Thanks,
Eric